### PR TITLE
Adds clipBeavior for rendering radius borders

### DIFF
--- a/lib/features/user_auth/presentation/widgets/form_container_widget.dart
+++ b/lib/features/user_auth/presentation/widgets/form_container_widget.dart
@@ -43,6 +43,7 @@ class _FormContainerWidgetState extends State<FormContainerWidget> {
   Widget build(BuildContext context) {
     return Container(
       width: double.infinity,
+      clipBehavior: Clip.hardEdge,
       decoration: BoxDecoration(
         color: Colors.grey.withOpacity(.35),
         borderRadius: BorderRadius.circular(10),


### PR DESCRIPTION
I had to add this to correct the rendering on a Mac running Apple silicon.

## Before:
<img width="411" alt="Before" src="https://github.com/hassank185/Flutter-Firebase-Series/assets/3665012/e2058d26-06a5-4aeb-853d-acef2e46bc8e">

## After:
<img width="404" alt="After" src="https://github.com/hassank185/Flutter-Firebase-Series/assets/3665012/31859b91-f742-48e9-bb79-31f083719c94">



